### PR TITLE
update `band.kessoku.scripts`

### DIFF
--- a/base/fabric/build.gradle
+++ b/base/fabric/build.gradle
@@ -1,10 +1,10 @@
-import net.fabricmc.loom.util.ModPlatform
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
 base.archivesName = rootProject.name + "-base"
 
 kessoku {
-    common("base", ModPlatform.FABRIC)
-    shadowBundle("base", ModPlatform.FABRIC)
+    common("base", PlatformIdentifier.FABRIC)
+    shadowBundle("base", PlatformIdentifier.FABRIC)
 }

--- a/base/neo/build.gradle
+++ b/base/neo/build.gradle
@@ -1,10 +1,10 @@
-import net.fabricmc.loom.util.ModPlatform
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
 base.archivesName = rootProject.name + "-base"
 
 kessoku {
-    common("base", ModPlatform.NEOFORGE)
-    shadowBundle("base", ModPlatform.NEOFORGE)
+    common("base", PlatformIdentifier.NEO)
+    shadowBundle("base", PlatformIdentifier.NEO)
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,14 +11,15 @@ repositories {
 
 dependencies {
     gradleApi()
+
     implementation("dev.architectury:architectury-loom:${readLoomVersion()}")
 }
 
 gradlePlugin {
     plugins {
-        create("kessoku") {
+        create("kessoku-gradle-plugin") {
             id = "band.kessoku.scripts"
-            implementationClass = "band.kessoku.gradle.plugin.KessokuGradlePlugin"
+            implementationClass = "band.kessoku.scripts.gradle.plugin.KessokuGradlePlugin"
         }
     }
 }

--- a/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuExtension.java
+++ b/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuExtension.java
@@ -31,17 +31,6 @@ public abstract class KessokuExtension {
         return MODULES;
     }
 
-    public void modRuntimeLibrary(Object lib) {
-        Project project = this.getProject();
-        DependencyHandler dependencies = project.getDependencies();
-
-        Dependency dependency = dependencies.project(Map.of(
-                "path", lib,
-                "configuration", "namedElements"
-        ));
-        dependencies.add("implementation", dependency);
-    }
-
     public void testModules(List<String> names, PlatformIdentifier platform) {
         names.forEach(name -> {
             Project project = this.getProject();

--- a/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuExtension.java
+++ b/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuExtension.java
@@ -77,7 +77,7 @@ public abstract class KessokuExtension {
         });
     }
 
-    public void common(String name, ModPlatform platform) {
+    public void common(String name, PlatformIdentifier platform) {
         Project project = this.getProject();
         DependencyHandler dependencies = project.getDependencies();
 
@@ -88,16 +88,16 @@ public abstract class KessokuExtension {
         dependency.setTransitive(false);
         dependencies.add("compileOnly", dependency);
         dependencies.add("runtimeOnly", dependency);
-        dependencies.add("development" + platform.displayName(), dependency);
+        dependencies.add("development" + platform.platform().displayName(), dependency);
     }
 
-    public void shadowBundle(String name, ModPlatform platform) {
+    public void shadowBundle(String name, PlatformIdentifier platform) {
         Project project = this.getProject();
         DependencyHandler dependencies = project.getDependencies();
 
         Dependency dependency = dependencies.project(Map.of(
                 "path", ":" + name + "-common",
-                "configuration", "transformProduction" + platform.displayName()
+                "configuration", "transformProduction" + platform.platform().displayName()
         ));
         dependencies.add("shade", dependency);
     }

--- a/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuExtension.java
+++ b/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuExtension.java
@@ -1,4 +1,4 @@
-package band.kessoku.gradle.plugin;
+package band.kessoku.scripts.gradle.plugin;
 
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.util.ModPlatform;
@@ -31,7 +31,7 @@ public abstract class KessokuExtension {
         return MODULES;
     }
 
-    public void library(String lib) {
+    public void modRuntimeLibrary(Object lib) {
         Project project = this.getProject();
         DependencyHandler dependencies = project.getDependencies();
 
@@ -42,55 +42,50 @@ public abstract class KessokuExtension {
         dependencies.add("implementation", dependency);
     }
 
-    public void testModules(List<String> names, String plat) {
-        names.forEach(name -> testModule(name, plat));
+    public void testModules(List<String> names, PlatformIdentifier platform) {
+        names.forEach(name -> {
+            Project project = this.getProject();
+            DependencyHandler dependencies = project.getDependencies();
+
+            Dependency dependency = dependencies.project(Map.of(
+                    "path", ":" + name + "-" + platform.id(),
+                    "configuration", "namedElements"
+            ));
+            dependencies.add("testImplementation", dependency);
+        });
     }
 
-    public void modules(List<String> names, String plat) {
-        names.forEach(name -> module(name, plat));
+    public void modules(List<String> names, PlatformIdentifier platform) {
+        names.forEach(name -> {
+            Project project = this.getProject();
+            DependencyHandler dependencies = project.getDependencies();
+
+            Dependency dependency = dependencies.project(Map.of(
+                    "path", ":" + name + "-" + platform.id(),
+                    "configuration", "namedElements"
+            ));
+            dependencies.add("api", dependency);
+            dependencies.add("implementation", dependency);
+
+            LoomGradleExtensionAPI loom = project.getExtensions().getByType(LoomGradleExtensionAPI.class);
+            loom.mods(mods -> mods.register("kessoku-" + name + "-" + platform.id(), settings -> {
+                Project depProject = project.project(":" + name + "-" + platform.id());
+                SourceSetContainer sourceSets = depProject.getExtensions().getByType(SourceSetContainer.class);
+                settings.sourceSet(sourceSets.getByName("main"), depProject);
+            }));
+        });
     }
 
-    public void moduleIncludes(List<String> names, String plat) {
-        names.forEach(name -> moduleInclude(name, plat));
-    }
+    public void moduleIncludes(List<String> names, PlatformIdentifier platform) {
+        names.forEach(name -> {
+            Project project = this.getProject();
+            DependencyHandler dependencies = project.getDependencies();
 
-    public void testModule(String name, String plat) {
-        Project project = this.getProject();
-        DependencyHandler dependencies = project.getDependencies();
-
-        Dependency dependency = dependencies.project(Map.of(
-                "path", ":" + name + "-" + plat,
-                "configuration", "namedElements"
-        ));
-        dependencies.add("testImplementation", dependency);
-    }
-
-    public void module(String name, String plat) {
-        Project project = this.getProject();
-        DependencyHandler dependencies = project.getDependencies();
-
-        Dependency dependency = dependencies.project(Map.of(
-                "path", ":" + name + "-" + plat,
-                "configuration", "namedElements"
-        ));
-        dependencies.add("api", dependency);
-
-        LoomGradleExtensionAPI loom = project.getExtensions().getByType(LoomGradleExtensionAPI.class);
-        loom.mods(mods -> mods.register("kessoku-" + name + "-" + plat, settings -> {
-            Project depProject = project.project(":" + name + "-" + plat);
-            SourceSetContainer sourceSets = depProject.getExtensions().getByType(SourceSetContainer.class);
-            settings.sourceSet(sourceSets.getByName("main"), depProject);
-        }));
-    }
-
-    public void moduleInclude(String name, String plat) {
-        Project project = this.getProject();
-        DependencyHandler dependencies = project.getDependencies();
-
-        Dependency dependency = dependencies.project(Map.of(
-                "path", ":" + name + "-" + plat
-        ));
-        dependencies.add("include", dependency);
+            Dependency dependency = dependencies.project(Map.of(
+                    "path", ":" + name + "-" + platform.id()
+            ));
+            dependencies.add("include", dependency);
+        });
     }
 
     public void common(String name, ModPlatform platform) {

--- a/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuGradlePlugin.java
+++ b/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/KessokuGradlePlugin.java
@@ -1,4 +1,4 @@
-package band.kessoku.gradle.plugin;
+package band.kessoku.scripts.gradle.plugin;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/PlatformIdentifier.java
+++ b/buildSrc/src/main/java/band/kessoku/scripts/gradle/plugin/PlatformIdentifier.java
@@ -1,4 +1,4 @@
-package band.kessoku.gradle.plugin;
+package band.kessoku.scripts.gradle.plugin;
 
 import net.fabricmc.loom.util.ModPlatform;
 
@@ -6,7 +6,8 @@ import java.util.Locale;
 
 public enum PlatformIdentifier {
     FABRIC("Fabric", ModPlatform.FABRIC),
-    NEO("Neo", ModPlatform.NEOFORGE)
+    NEO("Neo", ModPlatform.NEOFORGE),
+    COMMON("Common", null)
     ;
 
     private final String displayName;

--- a/command/common/build.gradle
+++ b/command/common/build.gradle
@@ -1,8 +1,10 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-command"
 
 kessoku {
-    module("base", "common")
-    testModule("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
+    testModules(["base"], PlatformIdentifier.COMMON)
 }

--- a/command/fabric/build.gradle
+++ b/command/fabric/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
@@ -8,6 +7,6 @@ base.archivesName = rootProject.name + "-command"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("command", ModPlatform.FABRIC)
-    shadowBundle("command", ModPlatform.FABRIC)
+    common("command", PlatformIdentifier.FABRIC)
+    shadowBundle("command", PlatformIdentifier.FABRIC)
 }

--- a/command/fabric/build.gradle
+++ b/command/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 base.archivesName = rootProject.name + "-command"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("command", ModPlatform.FABRIC)
     shadowBundle("command", ModPlatform.FABRIC)

--- a/command/neo/build.gradle
+++ b/command/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -9,6 +8,6 @@ kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
     modules(["base"], PlatformIdentifier.NEO)
 
-    common("command", ModPlatform.NEOFORGE)
-    shadowBundle("command", ModPlatform.NEOFORGE)
+    common("command", PlatformIdentifier.NEO)
+    shadowBundle("command", PlatformIdentifier.NEO)
 }

--- a/command/neo/build.gradle
+++ b/command/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -5,8 +6,8 @@ apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 base.archivesName = rootProject.name + "-command"
 
 kessoku {
-    module("base", "common")
-    module("base", "neo")
+    modules(["base"], PlatformIdentifier.COMMON)
+    modules(["base"], PlatformIdentifier.NEO)
 
     common("command", ModPlatform.NEOFORGE)
     shadowBundle("command", ModPlatform.NEOFORGE)

--- a/config/common/build.gradle
+++ b/config/common/build.gradle
@@ -1,9 +1,11 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-config"
 
 kessoku {
-    modules(["base", "platform"], "common")
+    modules(["base", "platform"], PlatformIdentifier.COMMON)
 }
 
 dependencies {

--- a/config/fabric/build.gradle
+++ b/config/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 base.archivesName = rootProject.name + "-config"
 
 kessoku {
-    modules(["base", "platform"], "common")
+    modules(["base", "platform"], PlatformIdentifier.COMMON)
 
     common("config", ModPlatform.FABRIC)
     shadowBundle("config", ModPlatform.FABRIC)

--- a/config/fabric/build.gradle
+++ b/config/fabric/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
@@ -8,8 +7,8 @@ base.archivesName = rootProject.name + "-config"
 kessoku {
     modules(["base", "platform"], PlatformIdentifier.COMMON)
 
-    common("config", ModPlatform.FABRIC)
-    shadowBundle("config", ModPlatform.FABRIC)
+    common("config", PlatformIdentifier.FABRIC)
+    shadowBundle("config", PlatformIdentifier.FABRIC)
 }
 
 dependencies {

--- a/config/neo/build.gradle
+++ b/config/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 base.archivesName = rootProject.name + "-config"
 
 kessoku {
-    modules(["base", "platform"], "common")
+    modules(["base", "platform"], PlatformIdentifier.COMMON)
 
     common("config", ModPlatform.NEOFORGE)
     shadowBundle("config", ModPlatform.NEOFORGE)

--- a/config/neo/build.gradle
+++ b/config/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -8,8 +7,8 @@ base.archivesName = rootProject.name + "-config"
 kessoku {
     modules(["base", "platform"], PlatformIdentifier.COMMON)
 
-    common("config", ModPlatform.NEOFORGE)
-    shadowBundle("config", ModPlatform.NEOFORGE)
+    common("config", PlatformIdentifier.NEO)
+    shadowBundle("config", PlatformIdentifier.NEO)
 }
 
 dependencies {

--- a/entrypoint/common/build.gradle
+++ b/entrypoint/common/build.gradle
@@ -1,10 +1,11 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-entrypoint"
 
 kessoku {
-    module("base", "common")
-    module("platform", "common")
+    modules(["base", "platform"], PlatformIdentifier.COMMON)
 }
 
 dependencies {

--- a/entrypoint/fabric/build.gradle
+++ b/entrypoint/fabric/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
@@ -8,8 +7,8 @@ base.archivesName = rootProject.name + "-entrypoint"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("entrypoint", ModPlatform.FABRIC)
-    shadowBundle("entrypoint", ModPlatform.FABRIC)
+    common("entrypoint", PlatformIdentifier.FABRIC)
+    shadowBundle("entrypoint", PlatformIdentifier.FABRIC)
 }
 
 dependencies {

--- a/entrypoint/fabric/build.gradle
+++ b/entrypoint/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 base.archivesName = rootProject.name + "-entrypoint"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("entrypoint", ModPlatform.FABRIC)
     shadowBundle("entrypoint", ModPlatform.FABRIC)

--- a/entrypoint/neo/build.gradle
+++ b/entrypoint/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -8,6 +7,6 @@ base.archivesName = rootProject.name + "-entrypoint"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("entrypoint", ModPlatform.NEOFORGE)
-    shadowBundle("entrypoint", ModPlatform.NEOFORGE)
+    common("entrypoint",PlatformIdentifier.NEO)
+    shadowBundle("entrypoint", PlatformIdentifier.NEO)
 }

--- a/entrypoint/neo/build.gradle
+++ b/entrypoint/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 base.archivesName = rootProject.name + "-entrypoint"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("entrypoint", ModPlatform.NEOFORGE)
     shadowBundle("entrypoint", ModPlatform.NEOFORGE)

--- a/event/common/build.gradle
+++ b/event/common/build.gradle
@@ -1,7 +1,9 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-event"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 }

--- a/event/fabric/build.gradle
+++ b/event/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 base.archivesName = rootProject.name + "-event"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("event", ModPlatform.FABRIC)
     shadowBundle("event", ModPlatform.FABRIC)

--- a/event/fabric/build.gradle
+++ b/event/fabric/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
@@ -8,6 +7,6 @@ base.archivesName = rootProject.name + "-event"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("event", ModPlatform.FABRIC)
-    shadowBundle("event", ModPlatform.FABRIC)
+    common("event", PlatformIdentifier.FABRIC)
+    shadowBundle("event", PlatformIdentifier.FABRIC)
 }

--- a/event/neo/build.gradle
+++ b/event/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -5,8 +6,8 @@ apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 base.archivesName = rootProject.name + "-event"
 
 kessoku {
-    module("base", "common")
-    module("base", "neo")
+    modules(["base"], PlatformIdentifier.COMMON)
+    modules(["base"], PlatformIdentifier.NEO)
 
     common("event", ModPlatform.NEOFORGE)
     shadowBundle("event", ModPlatform.NEOFORGE)

--- a/event/neo/build.gradle
+++ b/event/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -9,6 +8,6 @@ kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
     modules(["base"], PlatformIdentifier.NEO)
 
-    common("event", ModPlatform.NEOFORGE)
-    shadowBundle("event", ModPlatform.NEOFORGE)
+    common("event", PlatformIdentifier.NEO)
+    shadowBundle("event", PlatformIdentifier.NEO)
 }

--- a/keybinding/common/build.gradle
+++ b/keybinding/common/build.gradle
@@ -1,7 +1,9 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-keybinding"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 }

--- a/keybinding/fabric/build.gradle
+++ b/keybinding/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 base.archivesName = rootProject.name + "-keybinding"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("keybinding", ModPlatform.FABRIC)
     shadowBundle("keybinding", ModPlatform.FABRIC)

--- a/keybinding/fabric/build.gradle
+++ b/keybinding/fabric/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
@@ -8,6 +7,6 @@ base.archivesName = rootProject.name + "-keybinding"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("keybinding", ModPlatform.FABRIC)
-    shadowBundle("keybinding", ModPlatform.FABRIC)
+    common("keybinding", PlatformIdentifier.FABRIC)
+    shadowBundle("keybinding", PlatformIdentifier.FABRIC)
 }

--- a/keybinding/neo/build.gradle
+++ b/keybinding/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -5,8 +6,8 @@ apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 base.archivesName = rootProject.name + "-keybinding"
 
 kessoku {
-    module("base", "common")
-    module("base", "neo")
+    modules(["base"], PlatformIdentifier.COMMON)
+    modules(["base"], PlatformIdentifier.NEO)
 
     common("keybinding", ModPlatform.NEOFORGE)
     shadowBundle("keybinding", ModPlatform.NEOFORGE)

--- a/keybinding/neo/build.gradle
+++ b/keybinding/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -9,6 +8,6 @@ kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
     modules(["base"], PlatformIdentifier.NEO)
 
-    common("keybinding", ModPlatform.NEOFORGE)
-    shadowBundle("keybinding", ModPlatform.NEOFORGE)
+    common("keybinding", PlatformIdentifier.NEO)
+    shadowBundle("keybinding", PlatformIdentifier.NEO)
 }

--- a/platform/common/build.gradle
+++ b/platform/common/build.gradle
@@ -1,7 +1,9 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-platform"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 }

--- a/platform/fabric/build.gradle
+++ b/platform/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 base.archivesName = rootProject.name + "-platform"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("platform", ModPlatform.FABRIC)
     shadowBundle("platform", ModPlatform.FABRIC)

--- a/platform/fabric/build.gradle
+++ b/platform/fabric/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
@@ -8,6 +7,6 @@ base.archivesName = rootProject.name + "-platform"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("platform", ModPlatform.FABRIC)
-    shadowBundle("platform", ModPlatform.FABRIC)
+    common("platform", PlatformIdentifier.FABRIC)
+    shadowBundle("platform", PlatformIdentifier.FABRIC)
 }

--- a/platform/neo/build.gradle
+++ b/platform/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -5,7 +6,7 @@ apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 base.archivesName = rootProject.name + "-platform"
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("platform", ModPlatform.NEOFORGE)
     shadowBundle("platform", ModPlatform.NEOFORGE)

--- a/platform/neo/build.gradle
+++ b/platform/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -8,6 +7,6 @@ base.archivesName = rootProject.name + "-platform"
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("platform", ModPlatform.NEOFORGE)
-    shadowBundle("platform", ModPlatform.NEOFORGE)
+    common("platform", PlatformIdentifier.NEO)
+    shadowBundle("platform", PlatformIdentifier.NEO)
 }

--- a/registry/common/build.gradle
+++ b/registry/common/build.gradle
@@ -1,3 +1,5 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
+
 apply from: rootProject.file("gradle/scripts/klib-common.gradle")
 
 base.archivesName = rootProject.name + "-registry"
@@ -7,8 +9,5 @@ loom {
 }
 
 kessoku {
-    modules(["base", "platform"], "common")
-}
-
-dependencies {
+    modules(["base", "platform"], PlatformIdentifier.COMMON)
 }

--- a/registry/fabric/build.gradle
+++ b/registry/fabric/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
@@ -9,7 +10,7 @@ loom {
 }
 
 kessoku {
-    module("base", "common")
+    modules(["base"], PlatformIdentifier.COMMON)
 
     common("registry", ModPlatform.FABRIC)
     shadowBundle("registry", ModPlatform.FABRIC)

--- a/registry/fabric/build.gradle
+++ b/registry/fabric/build.gradle
@@ -12,6 +12,6 @@ loom {
 kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
 
-    common("registry", ModPlatform.FABRIC)
-    shadowBundle("registry", ModPlatform.FABRIC)
+    common("registry", PlatformIdentifier.FABRIC)
+    shadowBundle("registry", PlatformIdentifier.FABRIC)
 }

--- a/registry/neo/build.gradle
+++ b/registry/neo/build.gradle
@@ -1,5 +1,4 @@
 import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
-import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
@@ -13,8 +12,8 @@ kessoku {
     modules(["base"], PlatformIdentifier.COMMON)
     modules(["base"], PlatformIdentifier.NEO)
 
-    common("registry", ModPlatform.NEOFORGE)
-    shadowBundle("registry", ModPlatform.NEOFORGE)
+    common("registry", PlatformIdentifier.NEO)
+    shadowBundle("registry", PlatformIdentifier.NEO)
 }
 
 remapJar {

--- a/registry/neo/build.gradle
+++ b/registry/neo/build.gradle
@@ -1,3 +1,4 @@
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 import net.fabricmc.loom.util.ModPlatform
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
@@ -9,8 +10,8 @@ loom {
 }
 
 kessoku {
-    module("base", "common")
-    module("base", "neo")
+    modules(["base"], PlatformIdentifier.COMMON)
+    modules(["base"], PlatformIdentifier.NEO)
 
     common("registry", ModPlatform.NEOFORGE)
     shadowBundle("registry", ModPlatform.NEOFORGE)

--- a/wrapper/fabric/build.gradle
+++ b/wrapper/fabric/build.gradle
@@ -1,9 +1,9 @@
-import band.kessoku.gradle.plugin.PlatformIdentifier
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 
 apply from: rootProject.file("gradle/scripts/klib-fabric.gradle")
 
 base.archivesName = rootProject.name
 
 kessoku {
-    moduleIncludes(getModuleList(), PlatformIdentifier.FABRIC.id())
+    moduleIncludes(getModuleList(), PlatformIdentifier.FABRIC)
 }

--- a/wrapper/neo/build.gradle
+++ b/wrapper/neo/build.gradle
@@ -1,9 +1,9 @@
-import band.kessoku.gradle.plugin.PlatformIdentifier
+import band.kessoku.scripts.gradle.plugin.PlatformIdentifier
 
 apply from: rootProject.file("gradle/scripts/klib-neo.gradle")
 
 base.archivesName = rootProject.name
 
 kessoku {
-    moduleIncludes(getModuleList(), PlatformIdentifier.NEO.id())
+    moduleIncludes(getModuleList(), PlatformIdentifier.NEO)
 }


### PR DESCRIPTION
- remove `kessoku.library`
- rework impl module, now we can use `PlatformIdentifier` to mark the platform used, while the old method has been removed, as follows:

```gradle
kessoku {
    modules(["base"], PlatformIdentifier.COMMON)
}
```